### PR TITLE
Usesystemcommandline

### DIFF
--- a/.github/workflows/HelseId.Tools.publish.yml
+++ b/.github/workflows/HelseId.Tools.publish.yml
@@ -7,12 +7,13 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:  
+  workflow_dispatch:
+  release:
+    types: [created]  
 
 jobs:
-  publish:
+  build-and-publish-executable:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
   
@@ -24,10 +25,8 @@ jobs:
     - name: Build Project
       run: dotnet build ./src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj --configuration Release
 
-
-    - name: Publish
+    - name: Publish Executable
       run: dotnet publish  ./src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj --configuration Release --output publish_output --self-contained true -p:PublishSingleFile=true --runtime win-x64
-
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -35,3 +34,37 @@ jobs:
         name: published-app
         path: publish_output/
         retention-days: 2  # Optional: Set retention period
+
+  publish-nuget:
+    runs-on: ubuntu-latest
+    # Only run when a release is created
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/checkout@v4
+  
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Get version from tag
+      id: get_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+    - name: Pack NuGet package
+      run: |
+        dotnet pack ./src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj \
+        --configuration Release \
+        -p:PackageVersion=${{ steps.get_version.outputs.VERSION }} \
+        --output nuget-packages
+
+    - name: Publish NuGet package
+      run: dotnet nuget push ./nuget-packages/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      if: github.event_name == 'release'
+
+    - name: Upload NuGet Package Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-package
+        path: nuget-packages/*.nupkg
+        retention-days: 7

--- a/Fhi.HelseId.Tools.sln.DotSettings
+++ b/Fhi.HelseId.Tools.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Helse/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=updateclientkey/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# HelseID CLI Tool
+
+Command line tool for HelseID client configuration and key management.
+
+## Features
+
+- Generate RSA key pairs for use with HelseID
+- Update client keys in HelseID
+
+## Installation
+
+### As a .NET Tool
+
+This application is packaged as a .NET tool and can be installed either globally or locally.
+
+#### Global Installation
+
+```bash
+# Install globally from NuGet
+dotnet tool install --global Fhi.HelseIdSelvbetjening.CLI
+
+# Use from anywhere
+helseid-cli --help
+```
+
+#### Local Installation
+
+```bash
+# Create a tool manifest in your project if you don't have one
+dotnet new tool-manifest
+
+# Install as a local tool from NuGet
+dotnet tool install Fhi.HelseIdSelvbetjening.CLI
+
+# Use in the project
+dotnet tool run helseid-cli --help
+```
+
+### Development Installation
+
+If you're developing this tool or want to install from a local build:
+
+```bash
+# Install globally from a local source
+dotnet tool install --global --add-source ./src/Fhi.HelseIdSelvbetjening.CLI/nupkg Fhi.HelseIdSelvbetjening.CLI
+
+# Or install locally from a local source
+dotnet tool install --add-source ./src/Fhi.HelseIdSelvbetjening.CLI/nupkg Fhi.HelseIdSelvbetjening.CLI
+```
+
+### Manual Installation
+
+If you prefer to run the tool without installing it as a .NET tool:
+
+```bash
+# Clone the repository
+git clone https://github.com/folkehelseinstituttet/Fhi.HelseId.Tools.git
+
+# Navigate to the CLI project
+cd Fhi.HelseId.Tools/src/Fhi.HelseIdSelvbetjening.CLI
+
+# Run the application
+dotnet run -- --help
+```
+
+## Usage
+
+### Generate Key Command
+
+Generate a new RSA key pair:
+
+```bash
+helseid-cli generatekey --keyFileNamePrefix MyClient --keyDirectory C:\Keys
+```
+
+Or with short options:
+
+```bash
+helseid-cli generatekey -n MyClient -d C:\Keys
+```
+
+### Update Client Key Command
+
+Update a client key in HelseID:
+
+```bash
+helseid-cli updateclientkey --clientId "your-client-id" --newPublicJwkPath "path/to/public.json" --existingPrivateJwkPath "path/to/private.json"
+```
+
+Or by providing the key values directly:
+
+```bash
+helseid-cli updateclientkey --clientId "your-client-id" --newPublicJwk "{...jwk json...}" --existingPrivateJwk "{...jwk json...}"
+```
+
+## Packaging
+
+To package the application as a NuGet package:
+
+```bash
+# Navigate to the CLI project
+cd src/Fhi.HelseIdSelvbetjening.CLI
+
+# Create the NuGet package
+dotnet pack
+
+# The package will be created in the ./nupkg directory
+```
+
+## License
+
+MIT

--- a/package-tool.ps1
+++ b/package-tool.ps1
@@ -1,0 +1,34 @@
+#!/usr/bin/env pwsh
+# Script to package the HelseID CLI as a .NET tool
+
+# Navigate to the CLI project directory
+$cliProjectDir = "$PSScriptRoot\src\Fhi.HelseIdSelvbetjening.CLI"
+Push-Location $cliProjectDir
+
+# Clean any previous packages
+if (Test-Path "nupkg") {
+    Write-Host "Cleaning previous packages..."
+    Remove-Item -Recurse -Force "nupkg"
+}
+
+# Build and pack the tool
+Write-Host "Building and packaging the tool..."
+dotnet pack -c Release
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to create package" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nPackage created successfully in $cliProjectDir\nupkg" -ForegroundColor Green
+
+# Display installation instructions
+Write-Host "`nTo install the tool globally, run:" -ForegroundColor Yellow
+Write-Host "dotnet tool install --global --add-source $cliProjectDir\nupkg Fhi.HelseIdSelvbetjening.CLI"
+
+Write-Host "`nTo install the tool in a local tool manifest, run:" -ForegroundColor Yellow
+Write-Host "dotnet new tool-manifest   # if you don't have one"
+Write-Host "dotnet tool install --add-source $cliProjectDir\nupkg Fhi.HelseIdSelvbetjening.CLI"
+
+# Return to the original directory
+Pop-Location

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Fhi.HelseIdSelvbetjening.CLI.csproj
@@ -6,6 +6,18 @@
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    
+    <!-- .NET Tool Configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>helseid-cli</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <Version>1.0.0</Version>
+    <Authors>FHI</Authors>
+    <Company>Folkehelseinstituttet</Company>
+    <Description>Command line tool for HelseID client configuration and key management</Description>
+    <PackageTags>helseid;cli;configuration;key management</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/folkehelseinstituttet/Fhi.HelseId.Tools</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
@@ -1,3 +1,5 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
 using Fhi.HelseId.Selvbetjening;
 using Fhi.HelseIdSelvbetjening.Services;
 using Fhi.HelseIdSelvbetjening.Services.Models;
@@ -8,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 
 /// <summary>
-/// Executable Program for HelseId Serlvbetjening CLI
+/// Executable Program for HelseId Selvbetjening CLI
 /// </summary>
 public partial class Program
 {
@@ -16,91 +18,168 @@ public partial class Program
     /// Main program
     /// </summary>
     /// <param name="args"></param>
-    public static void Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
-        var host = Host.CreateDefaultBuilder(args)
-        .ConfigureAppConfiguration(config =>
-           {
-               config.AddCommandLine(args);
-           })
-        .ConfigureServices((context, services) =>
-        {
-            ConfigureServices(args, context, services);
-        })
-        .ConfigureLogging((context, config) =>
-        {
-            Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .WriteTo.Console()
-                    .CreateLogger();
+        // Setup logging
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Console()
+            .CreateLogger();
 
-            config.ClearProviders();
-            config.AddSerilog(Log.Logger, dispose: true);
-        })
-        .Build();
+        // Create the host
+        var host = CreateHostBuilder(args).Build();
 
-        host.Run();
+        // Create root command
+        var rootCommand = new RootCommand("HelseID self-service command line tool");
+
+        // Configure generate-key command
+        var generateKeyCommand = new Command("generatekey", "Generate a new RSA key pair");
+        generateKeyCommand.AddAlias("generate-key");
+        
+        var keyNameOption = new Option<string>(
+            new[] { "--keyFileNamePrefix", "-n" },
+            "Prefix for the key file names");
+
+        var keyDirOption = new Option<string>(
+            new[] { "--keyDirectory", "-d" },
+            "Directory to store the generated keys");
+            
+        generateKeyCommand.AddOption(keyNameOption);
+        generateKeyCommand.AddOption(keyDirOption);
+        generateKeyCommand.Handler = CommandHandler.Create<string?, string?>(
+            (keyFileNamePrefix, keyDirectory) => HandleGenerateKeyCommand(keyFileNamePrefix, keyDirectory, host));
+        rootCommand.AddCommand(generateKeyCommand);
+
+        // Configure update-client-key command
+        var updateClientKeyCommand = new Command("updateclientkey", "Update a client key in HelseID");
+        updateClientKeyCommand.AddAlias("update-client-key");
+        
+        var clientIdOption = new Option<string>(
+            new[] { "--clientId", "-c" },
+            "Client ID to update")
+        { IsRequired = true };
+            
+        var newPublicJwkPathOption = new Option<string>(
+            new[] { "--newPublicJwkPath", "-np" },
+            "Path to the new public key file");
+            
+        var existingPrivateJwkPathOption = new Option<string>(
+            new[] { "--existingPrivateJwkPath", "-ep" },
+            "Path to the existing private key file");
+            
+        var newPublicJwkOption = new Option<string>(
+            new[] { "--newPublicJwk", "-n" },
+            "New public key value");
+            
+        var existingPrivateJwkOption = new Option<string>(
+            new[] { "--existingPrivateJwk", "-e" },
+            "Existing private key value");
+            
+        updateClientKeyCommand.AddOption(clientIdOption);
+        updateClientKeyCommand.AddOption(newPublicJwkPathOption);
+        updateClientKeyCommand.AddOption(existingPrivateJwkPathOption);
+        updateClientKeyCommand.AddOption(newPublicJwkOption);
+        updateClientKeyCommand.AddOption(existingPrivateJwkOption);
+        updateClientKeyCommand.Handler = CommandHandler.Create<string, string?, string?, string?, string?>(
+            (clientId, newPublicJwkPath, existingPrivateJwkPath, newPublicJwk, existingPrivateJwk) => 
+                HandleUpdateClientKeyCommand(clientId, newPublicJwkPath, existingPrivateJwkPath, newPublicJwk, existingPrivateJwk, host));
+        rootCommand.AddCommand(updateClientKeyCommand);
+
+        // Parse and invoke the command
+        return await rootCommand.InvokeAsync(args);
     }
 
-    internal static void ConfigureServices(string[] args, HostBuilderContext context, IServiceCollection services)
+    private static async Task<int> HandleGenerateKeyCommand(string? keyFileNamePrefix, string? keyDirectory, IHost host)
     {
-        services.AddSingleton<IFileHandler, FileHandler>();
-
-        var command = args.Length > 0 ? args[0] : null;
-        if (command == "generatekey")
+        try
         {
-            services.AddSingleton(provider =>
+            var parameters = new GenerateKeyParameters
             {
-                var config = provider.GetRequiredService<IConfiguration>();
-                return new GenerateKeyParameters
-                {
-                    KeyFileNamePrefix = config[nameof(GenerateKeyParameters.KeyFileNamePrefix)],
-                    KeyDirectory = config[nameof(GenerateKeyParameters.KeyDirectory)]
-                };
-            });
+                KeyFileNamePrefix = keyFileNamePrefix,
+                KeyDirectory = keyDirectory
+            };
 
-            services.AddHostedService<KeyGeneratorService>();
-
+            var logger = host.Services.GetRequiredService<ILogger<KeyGeneratorService>>();
+            var fileWriter = host.Services.GetRequiredService<IFileHandler>();
+            var service = new KeyGeneratorService(parameters, fileWriter, logger);
+            
+            await service.ExecuteAsync();
+            return 0;
         }
-        else if (command == "updateclientkey")
+        catch (Exception ex)
         {
-            Console.WriteLine($"Environment: {context.HostingEnvironment.EnvironmentName}");
-            Console.WriteLine($"Update client in environment {context.HostingEnvironment.EnvironmentName}? y/n");
+            Console.Error.WriteLine($"Error generating key: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> HandleUpdateClientKeyCommand(
+        string clientId, 
+        string? newPublicJwkPath, 
+        string? existingPrivateJwkPath,
+        string? newPublicJwk,
+        string? existingPrivateJwk,
+        IHost host)
+    {
+        try
+        {
+            Console.WriteLine($"Environment: {host.Services.GetRequiredService<IHostEnvironment>().EnvironmentName}");
+            Console.WriteLine($"Update client in environment {host.Services.GetRequiredService<IHostEnvironment>().EnvironmentName}? y/n");
 
             var input = Console.ReadLine();
             if (input?.Trim().ToLower() != "y")
             {
                 Console.WriteLine("Operation cancelled.");
-                return;
+                return 0;
             }
 
-            var configuration = new ConfigurationBuilder()
-                            .SetBasePath(AppContext.BaseDirectory)
-                            .AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", optional: false)
-                            .AddCommandLine(args)
-                            .Build();
-
-            services.AddSingleton(provider =>
+            var parameters = new UpdateClientKeyParameters
             {
-                var config = provider.GetRequiredService<IConfiguration>();
-                var clientId = config["ClientId"];
-                return new UpdateClientKeyParameters
-                {
-                    ClientId = config[nameof(UpdateClientKeyParameters.ClientId)] ?? string.Empty,
-                    NewPublicJwkPath = config[nameof(UpdateClientKeyParameters.NewPublicJwkPath)],
-                    ExistingPrivateJwkPath = config[nameof(UpdateClientKeyParameters.ExistingPrivateJwkPath)],
-                    ExisitingPrivateJwk = config[nameof(UpdateClientKeyParameters.ExisitingPrivateJwk)],
-                    NewPublicJwk = config[nameof(UpdateClientKeyParameters.NewPublicJwk)]
-                };
-            });
-            services.AddHostedService<ClientKeyUpdaterService>();
+                ClientId = clientId,
+                NewPublicJwkPath = newPublicJwkPath,
+                ExistingPrivateJwkPath = existingPrivateJwkPath,
+                ExisitingPrivateJwk = existingPrivateJwk,
+                NewPublicJwk = newPublicJwk
+            };
 
-            services.Configure<SelvbetjeningConfiguration>(configuration.GetSection("SelvbetjeningConfiguration"));
-            services.AddSelvbetjeningServices();
+            var logger = host.Services.GetRequiredService<ILogger<ClientKeyUpdaterService>>();
+            var fileHandler = host.Services.GetRequiredService<IFileHandler>();
+            var helseIdService = host.Services.GetRequiredService<IHelseIdSelvbetjeningService>();
+            
+            var service = new ClientKeyUpdaterService(parameters, helseIdService, fileHandler, logger);
+            
+            await service.ExecuteAsync();
+            return 0;
         }
-        else
+        catch (Exception ex)
         {
-            services.AddSingleton<IHostedService, InvalidCommandService>();
+            Console.Error.WriteLine($"Error updating client key: {ex.Message}");
+            return 1;
         }
     }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureAppConfiguration((hostContext, config) =>
+            {
+                config.AddJsonFile($"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);
+                config.AddCommandLine(args);
+            })
+            .ConfigureServices((context, services) =>
+            {
+                // Register common services
+                services.AddTransient<IFileHandler, FileHandler>();
+                
+                // Register HelseId services for the updateclientkey command
+                if (args.Length > 0 && args[0].ToLower() == "updateclientkey")
+                {
+                    services.Configure<SelvbetjeningConfiguration>(context.Configuration.GetSection("SelvbetjeningConfiguration"));
+                    services.AddSelvbetjeningServices();
+                }
+            })
+            .ConfigureLogging((context, config) =>
+            {
+                config.ClearProviders();
+                config.AddSerilog(Log.Logger, dispose: true);
+            });
 }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
@@ -37,11 +37,11 @@ public partial class Program
         generateKeyCommand.AddAlias("generate-key");
         
         var keyNameOption = new Option<string>(
-            new[] { "--keyFileNamePrefix", "-n" },
+            ["--keyFileNamePrefix", "-n"],
             "Prefix for the key file names");
 
         var keyDirOption = new Option<string>(
-            new[] { "--keyDirectory", "-d" },
+            ["--keyDirectory", "-d"],
             "Directory to store the generated keys");
             
         generateKeyCommand.AddOption(keyNameOption);
@@ -55,24 +55,24 @@ public partial class Program
         updateClientKeyCommand.AddAlias("update-client-key");
         
         var clientIdOption = new Option<string>(
-            new[] { "--clientId", "-c" },
+                ["--clientId", "-c"],
             "Client ID to update")
         { IsRequired = true };
             
         var newPublicJwkPathOption = new Option<string>(
-            new[] { "--newPublicJwkPath", "-np" },
+            ["--newPublicJwkPath", "-np"],
             "Path to the new public key file");
             
         var existingPrivateJwkPathOption = new Option<string>(
-            new[] { "--existingPrivateJwkPath", "-ep" },
+            ["--existingPrivateJwkPath", "-ep"],
             "Path to the existing private key file");
             
         var newPublicJwkOption = new Option<string>(
-            new[] { "--newPublicJwk", "-n" },
+            ["--newPublicJwk", "-n"],
             "New public key value");
             
         var existingPrivateJwkOption = new Option<string>(
-            new[] { "--existingPrivateJwk", "-e" },
+            ["--existingPrivateJwk", "-e"],
             "Existing private key value");
             
         updateClientKeyCommand.AddOption(clientIdOption);
@@ -108,7 +108,7 @@ public partial class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Error generating key: {ex.Message}");
+            await Console.Error.WriteLineAsync($"Error generating key: {ex.Message}");
             return 1;
         }
     }
@@ -153,7 +153,7 @@ public partial class Program
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Error updating client key: {ex.Message}");
+            await Console.Error.WriteLineAsync($"Error updating client key: {ex.Message}");
             return 1;
         }
     }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Services/ClientKeyUpdaterService.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Services/ClientKeyUpdaterService.cs
@@ -1,9 +1,8 @@
 using Fhi.HelseIdSelvbetjening.Services;
 using Fhi.HelseIdSelvbetjening.Services.Models;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-internal class ClientKeyUpdaterService : IHostedService
+internal class ClientKeyUpdaterService
 {
     private readonly UpdateClientKeyParameters _parameters;
     private readonly IHelseIdSelvbetjeningService _helseIdSelvbetjeningService;
@@ -21,7 +20,7 @@ internal class ClientKeyUpdaterService : IHostedService
         _logger = logger;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public Task ExecuteAsync()
     {
         try
         {
@@ -50,11 +49,6 @@ internal class ClientKeyUpdaterService : IHostedService
             _logger.LogError(e.Message);
         }
 
-        return Task.CompletedTask;
-    }
-
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
         return Task.CompletedTask;
     }
 }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Services/ClientKeyUpdaterService.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Services/ClientKeyUpdaterService.cs
@@ -20,7 +20,7 @@ internal class ClientKeyUpdaterService
         _logger = logger;
     }
 
-    public Task ExecuteAsync()
+    public async Task ExecuteAsync()
     {
         try
         {
@@ -37,7 +37,7 @@ internal class ClientKeyUpdaterService
             {
                 _logger.LogInformation("NewKey: {newKey}", newKey);
                 _logger.LogInformation("OldKey: {oldKey}", oldKey);
-                _helseIdSelvbetjeningService.UpdateClientSecret(new ClientConfiguration(_parameters.ClientId, oldKey), newKey);
+                await _helseIdSelvbetjeningService.UpdateClientSecret(new ClientConfiguration(_parameters.ClientId, oldKey), newKey);
             }
             else
             {
@@ -48,7 +48,5 @@ internal class ClientKeyUpdaterService
         {
             _logger.LogError(e.Message);
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Services/InvalidCommandService.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Services/InvalidCommandService.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
-internal class InvalidCommandService : IHostedService
+internal class InvalidCommandService
 {
     private readonly ILogger<InvalidCommandService> _logger;
 
@@ -10,11 +9,9 @@ internal class InvalidCommandService : IHostedService
         _logger = logger;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public Task ExecuteAsync()
     {
         _logger.LogError("Invalid command! Use 'generatekey' or 'updateclientkey'.");
         return Task.CompletedTask;
     }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Services/KeyGeneratorService.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Services/KeyGeneratorService.cs
@@ -1,10 +1,9 @@
 ﻿using Fhi.IdentityModel.Tokens;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Fhi.HelseIdSelvbetjening.Services
 {
-    internal class KeyGeneratorService : IHostedService
+    internal class KeyGeneratorService
     {
         private readonly GenerateKeyParameters _parameters;
         private readonly IFileHandler _fileWriter;
@@ -23,9 +22,8 @@ namespace Fhi.HelseIdSelvbetjening.Services
         /// privateKey will be named FileName_private.json
         /// privateKey will be named FileName_public.json 
         /// </summary>
-        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task StartAsync(CancellationToken cancellationToken)
+        public Task ExecuteAsync()
         {
             var keyPath = _parameters.KeyDirectory ?? Environment.CurrentDirectory;
             if (!Directory.Exists(keyPath))
@@ -45,11 +43,6 @@ namespace Fhi.HelseIdSelvbetjening.Services
             _logger.LogInformation("Private key saved: {@PrivateKeyPath}", privateKeyPath);
             _logger.LogInformation("Public key saved: {@PublicKeyPath}", publicKeyPath);
 
-            return Task.CompletedTask;
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
             return Task.CompletedTask;
         }
     }

--- a/tests/Fhi.HelseIdSelvbetjening.AcceptanceTests/Fhi.HelseIdSelvbetjening.AcceptanceTests.csproj
+++ b/tests/Fhi.HelseIdSelvbetjening.AcceptanceTests/Fhi.HelseIdSelvbetjening.AcceptanceTests.csproj
@@ -19,9 +19,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/ClientKeyUpdateTests.cs
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/ClientKeyUpdateTests.cs
@@ -16,7 +16,7 @@ namespace Fhi.HelseId.ClientSecret.App.Tests
             var helseIdServiceMock = Substitute.For<IHelseIdSelvbetjeningService>();
             var clientKeyUpdaterService = new ClientKeyUpdaterService(parameters, helseIdServiceMock, fileHandlerMock, loggerMock);
 
-            await clientKeyUpdaterService.StartAsync(CancellationToken.None);
+            await clientKeyUpdaterService.ExecuteAsync();
 
             loggerMock.Received(1).Log(
                LogLevel.Error,

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/ClientKeyUpdateTests.cs
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/ClientKeyUpdateTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fhi.HelseIdSelvbetjening.Services;
+using Fhi.HelseIdSelvbetjening.Services.Models;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -24,6 +25,75 @@ namespace Fhi.HelseId.ClientSecret.App.Tests
                Arg.Is<object>(o => o.ToString()!.Contains("Parameters empty.")),
                Arg.Any<Exception>(),
                Arg.Any<Func<object, Exception?, string>>());
+        }
+
+        [Test]
+        public async Task ClientKeyUpdate_WithValidParameters_UpdatesClientSecret()
+        {
+            // Arrange
+            var loggerMock = Substitute.For<ILogger<ClientKeyUpdaterService>>();
+            var fileHandlerMock = new FileHandlerMock();
+            var helseIdServiceMock = Substitute.For<IHelseIdSelvbetjeningService>();
+            
+            // Setup test data
+            var clientId = "test-client-id";
+            var existingPrivateJwkPath = "c:\\temp\\existing-private.json";
+            var newPublicJwkPath = "c:\\temp\\new-public.json";
+            var existingPrivateJwk = "{\"kid\":\"test-kid\",\"kty\":\"RSA\",\"private\":\"key-data\"}";
+            var newPublicJwk = "{\"kid\":\"new-kid\",\"kty\":\"RSA\",\"public\":\"key-data\"}";
+            
+            // Setup file handler mock to return the key contents
+            fileHandlerMock._files[existingPrivateJwkPath] = existingPrivateJwk;
+            fileHandlerMock._files[newPublicJwkPath] = newPublicJwk;
+            
+            var parameters = new UpdateClientKeyParameters 
+            { 
+                ClientId = clientId, 
+                NewPublicJwkPath = newPublicJwkPath, 
+                ExistingPrivateJwkPath = existingPrivateJwkPath 
+            };
+            
+            var clientKeyUpdaterService = new ClientKeyUpdaterService(
+                parameters, 
+                helseIdServiceMock, 
+                fileHandlerMock, 
+                loggerMock
+            );
+
+            // Act
+            await clientKeyUpdaterService.ExecuteAsync();
+
+            // Assert
+            // Verify the HelseId service was called with correct parameters
+            await helseIdServiceMock.Received(1).UpdateClientSecret(
+                Arg.Is<ClientConfiguration>(c => c.ClientId == clientId),
+                Arg.Is<string>(s => s == newPublicJwk)
+            );
+            
+            // Verify proper logging messages were logged
+            loggerMock.Received(1).Log(
+                LogLevel.Information,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains($"Update client {clientId}")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+            
+            loggerMock.Received(1).Log(
+                LogLevel.Information,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("NewKey:")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
+            
+            loggerMock.Received(1).Log(
+                LogLevel.Information,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("OldKey:")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>()
+            );
         }
     }
 }

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.Tests/HelseIdSelvbetjeningServiceTests.cs
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.Tests/HelseIdSelvbetjeningServiceTests.cs
@@ -1,0 +1,224 @@
+using Fhi.HelseIdSelvbetjening.Services;
+using Fhi.HelseIdSelvbetjening.Services.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Net;
+using System.Text.Json;
+
+namespace Fhi.HelseId.ClientSecret.App.Tests.Fhi.HelseIdSelvbetjening.Tests
+{
+    [TestFixture]
+    public class HelseIdSelvbetjeningServiceTests : IDisposable
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<HelseIdSelvbetjeningService> _logger;
+        private readonly IOptions<SelvbetjeningConfiguration> _selvbetjeningConfig;
+        private readonly HttpClient _httpClient;
+        private readonly MockHttpMessageHandler _mockHttpHandler;
+
+        public HelseIdSelvbetjeningServiceTests()
+        {
+            // Setup mocks
+            _logger = Substitute.For<ILogger<HelseIdSelvbetjeningService>>();
+            _selvbetjeningConfig = Substitute.For<IOptions<SelvbetjeningConfiguration>>();
+            _selvbetjeningConfig.Value.Returns(new SelvbetjeningConfiguration
+            {
+                Authority = "https://test.authority",
+                BaseAddress = "https://test.baseaddress",
+                ClientSecretEndpoint = "/api/client/secret"
+            });
+            
+            _httpClientFactory = Substitute.For<IHttpClientFactory>();
+            _mockHttpHandler = new MockHttpMessageHandler();
+            _httpClient = new HttpClient(_mockHttpHandler);
+            _httpClientFactory.CreateClient().Returns(_httpClient);
+        }
+
+        [Test]
+        public async Task UpdateClientSecret_SuccessfulUpdate_ReturnsSuccessResponse()
+        {
+            // Arrange
+            var clientId = "test-client-id";
+            var clientJwk = CreatePrivateJwk("test-kid");
+            var newPublicJwk = CreatePublicJwk("new-kid");
+            
+            var clientConfig = new ClientConfiguration(clientId, clientJwk);
+
+            // Setup the mock HTTP handler for the discovery document response
+            // Note: The issuer must match the authority for the test to pass
+            var discoveryJson = JsonSerializer.Serialize(new
+            {
+                issuer = "https://test.authority",
+                token_endpoint = "https://test.authority/connect/token",
+                jwks_uri = "https://test.authority/.well-known/openid-configuration/jwks"
+            });
+            
+            // Mock first request (discovery document)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Get,
+                "https://test.authority/.well-known/openid-configuration",
+                HttpStatusCode.OK, 
+                discoveryJson
+            );
+            
+            // Mock JWKS endpoint
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Get,
+                "https://test.authority/.well-known/openid-configuration/jwks",
+                HttpStatusCode.OK,
+                "{ \"keys\": [] }"
+            );
+
+            // Mock second request (token request with nonce requirement)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Post, 
+                "https://test.authority/connect/token",
+                HttpStatusCode.BadRequest, 
+                "{ \"error\": \"use_dpop_nonce\", \"dpop_nonce\": \"test-nonce\" }"
+            );
+
+            // Mock third request (token request with nonce)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Post, 
+                "https://test.authority/connect/token",
+                HttpStatusCode.OK, 
+                "{ \"access_token\": \"test-token\", \"token_type\": \"DPoP\", \"expires_in\": 3600 }"
+            );
+
+            // Mock fourth request (client secret update)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Post, 
+                "https://test.baseaddress/api/client/secret",
+                HttpStatusCode.OK, 
+                "{ \"success\": true }"
+            );
+
+            var service = new HelseIdSelvbetjeningService(_selvbetjeningConfig, _httpClientFactory, _logger);
+
+            // Act
+            var result = await service.UpdateClientSecret(clientConfig, newPublicJwk);
+
+            // Assert
+            Assert.That(result.HttpStatus, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(result.Message, Is.EqualTo("successfully updated client secret"));
+        }
+
+        [Test]
+        public void UpdateClientSecret_TokenRequestFails_ThrowsException()
+        {
+            // Arrange
+            var clientId = "test-client-id";
+            var clientJwk = CreatePrivateJwk("test-kid");
+            var newPublicJwk = CreatePublicJwk("new-kid");
+            
+            var clientConfig = new ClientConfiguration(clientId, clientJwk);
+
+            // Setup the mock HTTP handler for the discovery document response
+            var discoveryJson = JsonSerializer.Serialize(new
+            {
+                issuer = "https://test.authority",
+                token_endpoint = "https://test.authority/connect/token",
+                jwks_uri = "https://test.authority/.well-known/openid-configuration/jwks"
+            });
+            
+            // Mock first request (discovery document)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Get,
+                "https://test.authority/.well-known/openid-configuration",
+                HttpStatusCode.OK, 
+                discoveryJson
+            );
+            
+            // Mock JWKS endpoint
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Get,
+                "https://test.authority/.well-known/openid-configuration/jwks",
+                HttpStatusCode.OK,
+                "{ \"keys\": [] }"
+            );
+
+            // Mock second request (token request with error)
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Post,
+                "https://test.authority/connect/token",
+                HttpStatusCode.BadRequest, 
+                "{ \"error\": \"invalid_client\", \"error_description\": \"Invalid client authentication\" }"
+            );
+
+            var service = new HelseIdSelvbetjeningService(_selvbetjeningConfig, _httpClientFactory, _logger);
+
+            // Act & Assert
+            var exception = Assert.ThrowsAsync<Exception>(() => service.UpdateClientSecret(clientConfig, newPublicJwk));
+            
+            // The error message should be the error from the token response
+            Assert.That(exception.Message, Is.EqualTo("invalid_client"));
+        }
+
+        [Test]
+        public void UpdateClientSecret_DiscoveryFails_ThrowsException()
+        {
+            // Arrange
+            var clientId = "test-client-id";
+            var clientJwk = CreatePrivateJwk("test-kid");
+            var newPublicJwk = CreatePublicJwk("new-kid");
+            
+            var clientConfig = new ClientConfiguration(clientId, clientJwk);
+
+            // Mock discovery request to fail
+            _mockHttpHandler.AddResponse(
+                HttpMethod.Get,
+                "https://test.authority/.well-known/openid-configuration",
+                HttpStatusCode.InternalServerError, 
+                "{ \"error\": \"server_error\" }"
+            );
+
+            var service = new HelseIdSelvbetjeningService(_selvbetjeningConfig, _httpClientFactory, _logger);
+
+            // Act & Assert
+            var exception = Assert.ThrowsAsync<Exception>(() => service.UpdateClientSecret(clientConfig, newPublicJwk));
+            
+            // The error message starts with this prefix but may include more details
+            Assert.That(exception.Message, Does.StartWith("Error connecting to"));
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+
+        #region Helper Methods
+
+        private static string CreatePrivateJwk(string kid)
+        {
+            return @"{
+                ""kid"": """ + kid + @""",
+                ""kty"": ""RSA"",
+                ""alg"": ""RS256"",
+                ""n"": ""0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"",
+                ""e"": ""AQAB"",
+                ""d"": ""X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"",
+                ""p"": ""83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs"",
+                ""q"": ""3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk"",
+                ""dp"": ""G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0"",
+                ""dq"": ""s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk"",
+                ""qi"": ""GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU""
+            }";
+        }
+
+        private static string CreatePublicJwk(string kid)
+        {
+            return @"{
+                ""kid"": """ + kid + @""",
+                ""kty"": ""RSA"",
+                ""alg"": ""RS256"",
+                ""n"": ""0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"",
+                ""e"": ""AQAB""
+            }";
+        }
+
+        #endregion
+    }
+}

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.Tests/MockHttpMessageHandler.cs
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.Tests/MockHttpMessageHandler.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Text;
+
+namespace Fhi.HelseId.ClientSecret.App.Tests.Fhi.HelseIdSelvbetjening.Tests
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, HttpResponseMessage> _responses = new();
+
+        public void AddResponse(HttpMethod method, string url, HttpStatusCode statusCode, string content, string contentType = "application/json")
+        {
+            var key = $"{method}:{url}";
+            _responses[key] = new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(content, Encoding.UTF8, contentType)
+            };
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var key = $"{request.Method}:{request.RequestUri}";
+            
+            if (_responses.TryGetValue(key, out HttpResponseMessage? response))
+            {
+                return Task.FromResult(response);
+            }
+            
+            // Return not found if no matching response was configured
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+                Content = new StringContent($"No response configured for {request.Method} {request.RequestUri}")
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var response in _responses.Values)
+                {
+                    response.Dispose();
+                }
+                _responses.Clear();
+            }
+            
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.UnitTests.csproj
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.UnitTests.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/KeyGenerationTests.cs
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/KeyGenerationTests.cs
@@ -15,7 +15,7 @@ namespace Fhi.HelseId.ClientSecret.App.Tests
             var fileStore = new FileHandlerMock();
 
             var service = new KeyGeneratorService(parameters, fileStore, loggerMock);
-            await service.StartAsync(CancellationToken.None);
+            await service.ExecuteAsync();
 
             var expectedPublicKeyPath = Path.Combine(parameters.KeyDirectory, $"{parameters.KeyFileNamePrefix}_public.json");
             var expectedPrivateKeyPath = Path.Combine(parameters.KeyDirectory, $"{parameters.KeyFileNamePrefix}_private.json");
@@ -51,7 +51,7 @@ namespace Fhi.HelseId.ClientSecret.App.Tests
 
             var service = new KeyGeneratorService(parameters, fileStore, loggerMock);
 
-            await service.StartAsync(CancellationToken.None);
+            await service.ExecuteAsync();
 
             var expectedPublicKeyPath = Path.Combine(Environment.CurrentDirectory, $"{parameters.KeyFileNamePrefix}_public.json");
             var expectedPrivateKeyPath = Path.Combine(Environment.CurrentDirectory, $"{parameters.KeyFileNamePrefix}_private.json");


### PR DESCRIPTION

Fixes #5 

After talk with @jennyhougen , changed the tool from using HostedService to using the System.CommandLine library, which also allow for use of dependencyinjection, but remain being an ordinary command line application. It also have the same command line parsing.

Added so it can be used as a dotnet tool, and also added publishing to nuget , triggered by releasing it on github.

And, added some more unit tests.
And acceptance tests works. 

And yes, I got some help here.......

