### PR TITLE
Changes host running to start/stop

### DIFF
--- a/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Program.cs
@@ -39,7 +39,8 @@ public partial class Program
         })
         .Build();
 
-        await host.RunAsync();
+        await host.StartAsync();
+        await host.StopAsync();
     }
 
     internal static void ConfigureServices(string[] args, HostBuilderContext context, IServiceCollection services)


### PR DESCRIPTION
Seems like the app did not stop when using `await RunAsync`
Updates the host execution to use StartAsync and StopAsync instead of RunAsync. 
This allows the program to stop.