### PR TITLE
Adds documentation publishing workflow

### DIFF
--- a/.github/workflows/HelseId.Tools.publish.yml
+++ b/.github/workflows/HelseId.Tools.publish.yml
@@ -68,3 +68,22 @@ jobs:
         name: nuget-package
         path: nuget-packages/*.nupkg
         retention-days: 7
+
+  build-and-publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+      - name: Build MkDocs site
+        run: mkdocs build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site


### PR DESCRIPTION
Resolves https://github.com/FHIDev/Fhi.Fellesteam/issues/88

Adds a workflow to build and publish documentation using MkDocs and deploy it to GitHub Pages.