### PR TITLE
Adds verify-new-keys command

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/src/Fhi.HelseId.Selvbetjening/Http/ClientCredentialsRequestBuilder.cs
+++ b/src/Fhi.HelseId.Selvbetjening/Http/ClientCredentialsRequestBuilder.cs
@@ -8,7 +8,7 @@ namespace Fhi.HelseIdSelvbetjening.Http
     /// <summary>
     ///  Build ClientCredentialsTokenRequest
     /// </summary>
-    internal class ClientCredentialRequestBuilder
+    public class ClientCredentialRequestBuilder
     {
         private static ClientCredentialsTokenRequest _request = new();
         /// <summary>

--- a/src/Fhi.HelseId.Selvbetjening/ServiceCollectionExtensions.cs
+++ b/src/Fhi.HelseId.Selvbetjening/ServiceCollectionExtensions.cs
@@ -19,8 +19,6 @@ namespace Fhi.HelseId.Selvbetjening
         {
             services.AddSingleton<IOptions<SelvbetjeningConfiguration>, OptionsManager<SelvbetjeningConfiguration>>();
             services.AddTransient<IHelseIdSelvbetjeningService, HelseIdSelvbetjeningService>();
-            services.AddHttpClient();
-
             return services;
         }
     }

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Commands/VerifyNewKeysCommandConfiguration.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Commands/VerifyNewKeysCommandConfiguration.cs
@@ -1,0 +1,120 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using Fhi.HelseIdSelvbetjening.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using Fhi.HelseIdSelvbetjening.CLI.Services; // Ensure this using statement is present
+
+namespace Fhi.HelseIdSelvbetjening.CLI.Commands
+{
+    public static class VerifyNewKeysCommandConfiguration
+    {
+        public static Command CreateCommand(IHost host, string commandName) // IHost can be removed if not used elsewhere in this method for setup
+        {
+            var verifyCommand = new Command(commandName, "Verify a new client secret with HelseID");
+            verifyCommand.AddAlias("verify-new-keys");
+
+            var clientIdOption = new Option<string>(
+                aliases: ["--clientId", "-cid"],
+                description: "Client ID to verify")
+                { IsRequired = true };
+
+            var privateJwkOption = new Option<string>(
+                aliases: ["--privateJwk", "-jwk"], 
+                description: "The private key in JWK format (as a JSON string).")
+                { Arity = ArgumentArity.ZeroOrOne }; // Not required if path is used
+
+            var privateJwkPathOption = new Option<string>(
+                aliases: ["--privateJwkPath", "-path"],
+                description: "Path to the file containing the private key in JWK format.")
+                { Arity = ArgumentArity.ZeroOrOne }; // Not required if jwk string is used
+            
+            verifyCommand.AddOption(clientIdOption);
+            verifyCommand.AddOption(privateJwkOption);
+            verifyCommand.AddOption(privateJwkPathOption);
+
+            verifyCommand.AddValidator(result =>
+            {
+                var jwkOptionResult = result.FindResultFor(privateJwkOption);
+                var pathOptionResult = result.FindResultFor(privateJwkPathOption);
+                if (jwkOptionResult != null && pathOptionResult != null)
+                {
+                    result.ErrorMessage = "Cannot use both --privateJwk and --privateJwkPath simultaneously.";
+                }
+                else if (jwkOptionResult == null && pathOptionResult == null)
+                {
+                    result.ErrorMessage = "Either --privateJwk or --privateJwkPath must be specified.";
+                }
+            });
+
+            // Capture the 'host' instance from the CreateCommand method's parameter for the handler.
+            verifyCommand.Handler = CommandHandler.Create<string, string?, string?>(
+                (clientId, privateJwk, privateJwkPath) => 
+                    HandleVerifyNewKeysCommand(clientId, privateJwk, privateJwkPath, host)); // 'host' here is from the outer scope
+            
+            return verifyCommand;
+        }
+
+        private static async Task HandleVerifyNewKeysCommand(string clientId, string? privateJwk, string? privateJwkPath, IHost host) // This 'host' will now be the captured one
+        {
+            var logger = host.Services.GetRequiredService<ILogger<Program>>();
+            logger.LogInformation("Handling verify-new-keys command...");
+            logger.LogInformation("Received clientId: {ClientId}", clientId);
+            logger.LogInformation("Received privateJwk (raw string length): {Length}", privateJwk?.Length ?? 0);
+            logger.LogInformation("Received privateJwkPath: {Path}", privateJwkPath);
+
+            string? jwkToVerify = null;
+
+            if (!string.IsNullOrEmpty(privateJwkPath))
+            {
+                if (File.Exists(privateJwkPath))
+                {
+                    jwkToVerify = await File.ReadAllTextAsync(privateJwkPath);
+                    logger.LogInformation("Read JWK from path {Path}. Length: {Length}", privateJwkPath, jwkToVerify.Length);
+                }
+                else
+                {
+                    logger.LogError("Private JWK file not found at path: {Path}", privateJwkPath);
+                    Environment.ExitCode = 1;
+                    return;
+                }
+            }
+            else if (!string.IsNullOrEmpty(privateJwk))
+            {
+                try
+                {
+                    byte[] data = Convert.FromBase64String(privateJwk);
+                    jwkToVerify = System.Text.Encoding.UTF8.GetString(data);
+                    logger.LogInformation("Successfully Base64 decoded privateJwk. Decoded length: {Length}", jwkToVerify.Length);
+                }
+                catch (FormatException)
+                {
+                    logger.LogWarning("Received privateJwk is not a valid Base64 string. Assuming it's plain JSON.");
+                    jwkToVerify = privateJwk; 
+                }
+            }
+
+            if (string.IsNullOrEmpty(jwkToVerify))
+            {
+                logger.LogError("No private JWK to verify. Ensure --privateJwk or --privateJwkPath is provided correctly.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            using var scope = host.Services.CreateScope();
+            var verifyService = scope.ServiceProvider.GetRequiredService<IVerifyNewKeysService>();
+
+            logger.LogInformation("Calling verifyService.ExecuteAsync...");
+            var success = await verifyService.ExecuteAsync(clientId, jwkToVerify);
+            logger.LogInformation("verifyService.ExecuteAsync completed. Success: {SuccessState}", success);
+
+            if (!success)
+            {
+                Environment.ExitCode = 1;
+            }
+        }
+    }
+}

--- a/src/Fhi.HelseIdSelvbetjening.CLI/Services/VerifyNewKeysService.cs
+++ b/src/Fhi.HelseIdSelvbetjening.CLI/Services/VerifyNewKeysService.cs
@@ -1,0 +1,126 @@
+
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Fhi.HelseIdSelvbetjening.Http;
+using Fhi.HelseIdSelvbetjening.Services.Models;
+using Fhi.IdentityModel.Tokens;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Fhi.HelseIdSelvbetjening.CLI.Services
+{
+    public interface IVerifyNewKeysService
+    {
+        Task<bool> ExecuteAsync(string clientId, string privateJwk);
+    }
+
+    public class VerifyNewKeysService : IVerifyNewKeysService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly SelvbetjeningConfiguration _selvbetjeningConfiguration;
+        private readonly ILogger<VerifyNewKeysService> _logger;
+
+        public VerifyNewKeysService(
+            IHttpClientFactory httpClientFactory,
+            IOptions<SelvbetjeningConfiguration> selvbetjeningConfigurationOptions,
+            ILogger<VerifyNewKeysService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _selvbetjeningConfiguration = selvbetjeningConfigurationOptions.Value;
+            _logger = logger;
+        }
+
+        public async Task<bool> ExecuteAsync(string clientId, string privateJwk)
+        {
+            _logger.LogInformation("Attempting to verify new key for client ID: {ClientId}", clientId);
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient();
+                var disco = await client.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
+                {
+                    Address = _selvbetjeningConfiguration.Authority,
+                    Policy = { RequireHttps = true }
+                });
+
+                if (disco.IsError || disco.Issuer is null || disco.TokenEndpoint is null)
+                {
+                    _logger.LogError("Discovery document error: {Error}", disco.Error);
+                    return false;
+                }
+
+                _logger.LogInformation("Successfully retrieved discovery document from: {TokenEndpoint}", disco.TokenEndpoint);
+
+                // Request token using client assertion
+                var clientConfiguration = new ClientConfiguration(clientId, privateJwk);
+                var tokenResponse = await CreateToken(
+                    clientConfiguration,
+                    client,
+                    disco.TokenEndpoint,
+                    disco.Issuer,
+                    CreateDPoPKey());
+
+                if (tokenResponse.IsError)
+                {
+                    _logger.LogError("Token request error: {Error}. Description: {ErrorDescription}", tokenResponse.Error, tokenResponse.ErrorDescription);
+                    _logger.LogError("Raw response: {Raw}", tokenResponse.Raw);
+                    return false;
+                }
+
+                _logger.LogInformation("Successfully obtained token using the new key. Access Token: {AccessToken}", tokenResponse.AccessToken);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while verifying the new key.");
+                return false;
+            }
+        }
+        
+        private static string CreateDPoPKey()
+        {
+            var key = JwkGenerator.GenerateRsaJwk();
+
+            return key.PrivateKey;
+        }
+        
+        private async Task<TokenResponse> CreateToken(
+            ClientConfiguration clientToUpdate,
+            HttpClient client,
+            string tokenEndpoint,
+            string issuer,
+            string dPopJwk)
+        {
+            _logger.LogDebug("Dpop token nonce request");
+            var nonceRequest = new ClientCredentialRequestBuilder()
+                .Create(tokenEndpoint, clientToUpdate.ClientId)
+                .WithDPoP(tokenEndpoint, HttpMethod.Post.ToString(), dPopJwk, "PS256")
+                .WithClientAssertion(issuer, clientToUpdate.Jwk)
+                .WithScope("nhn:selvbetjening/client")
+                .Build();
+            var response = await client.RequestClientCredentialsTokenAsync(nonceRequest);
+
+            if (response.Error == "use_dpop_nonce" && response.DPoPNonce is not null)
+            {
+                _logger.LogDebug("Dpop token request with nonce");
+                var tokenRequest = new ClientCredentialRequestBuilder()
+                    .Create(tokenEndpoint, clientToUpdate.ClientId)
+                    .WithDPoPNonce(tokenEndpoint, HttpMethod.Post.ToString(), dPopJwk, "PS256", response.DPoPNonce)
+                    .WithClientAssertion(issuer, clientToUpdate.Jwk)
+                    .WithScope("nhn:selvbetjening/client")
+                    .Build();
+                response = await client.RequestClientCredentialsTokenAsync(tokenRequest);
+            }
+            else if (response.IsError)
+            {
+                throw new Exception(response.Error);
+            }
+
+            return response;
+        }
+    }
+}

--- a/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.UnitTests.csproj
+++ b/tests/Fhi.HelseIdSelvbetjening.UnitTests/Fhi.HelseIdSelvbetjening.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />


### PR DESCRIPTION
# Only created to get help in the tests
The tests for `VerifyNewKeys_WithGeneratedKey_Succeeds` works with Rider testrunner.
But when running it with dotnet cli (dotnet test) it fails...

I have tried logging out the different outputs and tried debugging, but don't understand what the difference is.
Suggestions?